### PR TITLE
Add missing bigint in Permission constructor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2205,7 +2205,7 @@ declare namespace Eris {
     allow: bigint;
     deny: bigint;
     json: Record<keyof Constants["Permissions"], boolean>;
-    constructor(allow: number | string, deny?: number | string);
+    constructor(allow: number | string | bigint, deny?: number | string | bigint);
     has(permission: keyof Constants["Permissions"]): boolean;
   }
 


### PR DESCRIPTION
Since you're updating typings around here, these are missing bigint